### PR TITLE
assignUserRoles return value fix

### DIFF
--- a/src/roleMapping.ts
+++ b/src/roleMapping.ts
@@ -24,9 +24,9 @@ export const assignUserRoles = async (
     endpoint: `users/${username}/roles`,
     method: "POST",
     body:
-      (roleNames.map((roleName) => {
-        name: roleName;
-      }) as RequestBody) ?? [],
+      (roleNames.map((roleName) => ({
+        name: roleName
+      })) as RequestBody) ?? [],
   });
 };
 


### PR DESCRIPTION
## 🎯 Summary

Modified the mapping function in assignUserRoles return value so that it correctly maps the body to an array of objects.

`() => {foo: bar;}` invokes the expression in the curly braces, `() => ({ foo: bar })` directly returns an object defined by the curly braces.


## 🔰 Checklist

- [x] I have read and agree with the following checklist and am following the guidelines in our [Code of Conduct](/CODE_OF_CONDUCT.md) document.

> - I have performed a self-review of my code.
> - I have commented my code, particularly in hard-to-understand areas.
> - I have made corresponding changes to the documentation where required.
> - I have tested my changes to the best of my ability.
> - I have consulted with the team if introducing a new dependency.
> - My changes generate no new warnings.
